### PR TITLE
feat: add spaced repetition generator

### DIFF
--- a/.github/workflows/spaced_repetition.yml
+++ b/.github/workflows/spaced_repetition.yml
@@ -1,0 +1,27 @@
+name: Generate spaced AGENTS
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run generator
+        run: |
+          python3 scripts/spaced_repetition.py
+      - name: Commit changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions"
+            git config user.email "github-actions@users.noreply.github.com"
+            git add AGENTS.md AGENTS.raw.md
+            git commit -m "chore: update AGENTS spaced repetition" && git push
+          fi

--- a/.github/workflows/spaced_repetition.yml
+++ b/.github/workflows/spaced_repetition.yml
@@ -9,7 +9,7 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -23,5 +23,5 @@ jobs:
             git config user.name "github-actions"
             git config user.email "github-actions@users.noreply.github.com"
             git add AGENTS.md AGENTS.raw.md
-            git commit -m "chore: update AGENTS spaced repetition" && git push
+            git commit -m "chore: update AGENTS spaced repetition [skip-agent]" && git push
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,70 +1,70 @@
 # Important rules for agents
 Grasping what's up: Check out README.md.
 Make: Explain high-level architecture and quirks in Makefile
-Pull requests: Branch names should match branch name recorded by Fibery if provided (e.g. "21648-switch-page-after-login-to-map").
-Debugging: Use TDD to handle bugs.
-Style: Do not break code indentation.
-SQL: Prefer indexed SQL operators when dealing with jsonb ( `tags @> '{"key": "value"}` instead of `tags ->> 'key' = 'value'` ).
-Front End: If Reatom v2 is used, upgrade it to v3.
-SQL: SQL is lowercase, PostGIS functions follow their spelling from the manual (`st_segmentize` -> `ST_Segmentize`).
 AI: Use system prompts where needed.
-Make: To smoke-check Makefile, `make --trace all` helps see dependency chain.
-Python: Write comments for each logical block.
+Pull requests: Branch names should match branch name recorded by Fibery if provided (e.g. "21648-switch-page-after-login-to-map").
+SQL: SQL is lowercase, PostGIS functions follow their spelling from the manual (`st_segmentize` -> `ST_Segmentize`).
+Style: Do not break code indentation.
+Debugging: Use TDD to handle bugs.
+SQL: Prefer indexed SQL operators when dealing with jsonb ( `tags @> '{"key": "value"}` instead of `tags ->> 'key' = 'value'` ).
 Style: Clean stuff up if you can: fix typos, make lexics more correct in English.
+Python: Write comments for each logical block.
+Make: To smoke-check Makefile, `make --trace all` helps see dependency chain.
 Testing: Github Actions is used as CI. Update it as necessary.
 AI: Check token counts.
 Pull requests: Keep Fibery ticket, Sentry ticket or other context relevant URL in pull request description.
-Make: Remember that Makefile uses tabs.
-SQL: Create both "up' and "down/rollback" migration when creating new migrations.
+Front End: If Reatom v2 is used, upgrade it to v3.
 Debugging: Keep working until the tests pass, do not stop before that.
-Style: Format the code nicely and consistently.
-Documentation: docs/ folder has general project documentation that needs to be kept up to date.
-Style: Do not replace URLs with non-existing ones.
+SQL: Create both "up' and "down/rollback" migration when creating new migrations.
+Make: Remember that Makefile uses tabs.
 AI: Colloquial "vectors" are to be called "embeddings" in codebase.
-Debugging: Add enough debug logs so you can find out what's wrong but not be overwhelmed when something does not work as expected.
+Style: Do not replace URLs with non-existing ones.
 SQL: Values in databases and layers should be absolute as much as possible: store "birthday" or "construction date" instead of "age".
 Java: Write enough comments so that people proficient in Python, PostGIS can grasp the Java code.
-Make: Trivial oneliner SQLs are okay to keep in Makefile.
-AI: Try to make a patch to fix/improve things even if user's request sounds like a question.
-Documentation: Don't update `README.md` with minor code fixes.
-Style: Start sentences at new lines in docs for cleaner git diffs.
-Debugging: Make sure that error messages towards developer are better than just "500 Internal server error".
-Testing: To run the pipeline in testing offline mode, launch `TEST_MODE=1 PYTHONPATH=. make -B -j all` and check if everything works as intended.
-k8s: When changing something in the charts, bump chart version to trigger deployment too.
-Grasping what's up: Check data schema as described in `docs/`.
-Java: Just ignoring exceptions is not the best fix, handle them properly.
-Make: Format target comments as self-documented Makefile, on same line: `target: dependencies | order_only_deps ## Description`
-Pull requests: Use Conventional Commits convention when formatting the pull request and commits, e.g. `type(scope): TICKETNUMBER title ...`. Skip ticket number if not provided. Field: Public Id.
-Documentation: Every feature needs to have comprehensive up-to-date documentation near it.
-SQL: SQL files should to be idempotent: drop table if exists; add some comments to make people grasp quereies faster.
-Style: If a file with code grows longer than 500 lines, refactor it into two or move some parts into already created libraries.
-SQL: Format queries in a way so it's easy to copy them out of the codebase and debug standalone.
-Style: Write insightful code comments.
-Grasping what's up: Check docs/
-Testing: Always add a custom assertion message when writing assertions in unit tests, including as much context as possible. Incorporate input data and relevant test details so it's immediately clear what is being verified and why it might fail.
-Documentation: Prefer storing notes and documentation as markdown (`.md`).
-CI: The project is using Github Actions. Make sure its configuration is kept up-to-date.
-Debugging: Don't stub stuff out with insane fallbacks (like lat/lon=0) - instead make the rest of the code work around data absence and inform user.
-Make: Makefile: If you need intermediate result from other target, split it into two and depend on the intermediate result.
-SQL: Do not rewrite old migrations, not for style changes, not for logic changes, always create new migrations for any changes in DB
-Debugging: When refactoring to move a feature, don't forget to remove the original code path.
 Documentation: Update docs every time you update something significant across files.
-Style: Do not mix tabs and spaces in code.
+Style: Start sentences at new lines in docs for cleaner git diffs.
+Java: Just ignoring exceptions is not the best fix, handle them properly.
+Make: Trivial oneliner SQLs are okay to keep in Makefile.
 Debugging: Inject data assertions into IO abstraction libraries to catch any data that violates them.
+Style: Format the code nicely and consistently.
+Debugging: Add enough debug logs so you can find out what's wrong but not be overwhelmed when something does not work as expected.
+Documentation: Every feature needs to have comprehensive up-to-date documentation near it.
+Grasping what's up: Check data schema as described in `docs/`.
+Debugging: Make sure that error messages towards developer are better than just "500 Internal server error".
+Documentation: Don't update `README.md` with minor code fixes.
+SQL: SQL files should to be idempotent: drop table if exists; add some comments to make people grasp quereies faster.
+k8s: When changing something in the charts, bump chart version to trigger deployment too.
+Pull requests: Use Conventional Commits convention when formatting the pull request and commits, e.g. `type(scope): TICKETNUMBER title ...`. Skip ticket number if not provided. Field: Public Id.
+Style: Write insightful code comments.
+AI: Try to make a patch to fix/improve things even if user's request sounds like a question.
+Make: Format target comments as self-documented Makefile, on same line: `target: dependencies | order_only_deps ## Description`
+Testing: To run the pipeline in testing offline mode, launch `TEST_MODE=1 PYTHONPATH=. make -B -j all` and check if everything works as intended.
+Style: If a file with code grows longer than 500 lines, refactor it into two or move some parts into already created libraries.
+Grasping what's up: Check docs/
+SQL: Format queries in a way so it's easy to copy them out of the codebase and debug standalone.
+Documentation: Prefer storing notes and documentation as markdown (`.md`).
+Testing: Always add a custom assertion message when writing assertions in unit tests, including as much context as possible. Incorporate input data and relevant test details so it's immediately clear what is being verified and why it might fail.
 Style: Add empty lines between logical blocks as in the rest of the codebase.
-Python: Write docstrings, they will get used for call graph and generated documentation.
+Make: Makefile: If you need intermediate result from other target, split it into two and depend on the intermediate result.
+CI: The project is using Github Actions. Make sure its configuration is kept up-to-date.
+Style: Do not mix tabs and spaces in code.
+Debugging: Don't stub stuff out with insane fallbacks (like lat/lon=0) - instead make the rest of the code work around data absence and inform user.
+Documentation: docs/ folder has general project documentation that needs to be kept up to date.
+Debugging: When refactoring to move a feature, don't forget to remove the original code path.
+SQL: Do not rewrite old migrations, not for style changes, not for logic changes, always create new migrations for any changes in DB
 Debugging: When adding logs, add message before starting something as long as after finishing, as it will let you find what crashed in the middle.
+Python: Write docstrings, they will get used for call graph and generated documentation.
 Testing: Code test coverage is measured by codecov. Write useful tests to increase it and check key requirements to hold.
-Testing: Use `make precommit` to run the checks. This sorts files, verifies Makefile tabs and compiles all Python code via `scripts/check_python.sh`.
 Documentation: API documentation is using Swagger, its descriptions should be clear for data consumers who don't have access to codebase.
 Debugging: File names may have spaces in them, check that you are correctly quoting and escaping them.
+Testing: Use `make precommit` to run the checks. This sorts files, verifies Makefile tabs and compiles all Python code via `scripts/check_python.sh`.
 Documentation: Fix everything in the `docs/` folder to match reality.
 Testing: For any fix you are implementing try to add test so that it won't repeat in the future.
-Debugging: Use TDD if change is not trivial: start by designing solution/docs, then write tests, then change code to do the thing it should.
 Style: Every feature needs to have comprehensive up-to-date documentation near it, write it.
-Documentation: When moving around md files also fix the links in them and links to them across all others.
 Debugging: Write enough comments so you can deduce what was a requirement in the future and not walk in circles.
+Documentation: When moving around md files also fix the links in them and links to them across all others.
+Debugging: Use TDD if change is not trivial: start by designing solution/docs, then write tests, then change code to do the thing it should.
+Documentation: Write extensive code comments in the code itself.
 Make: Makefile: there are comments on the same line after each target separated by ## - they are used in debug graph visualization, need to be concise and descriptive of what's going on in the code itself.
 Debugging: Use docs/todo.md as to put issues, inconveniences and impediments that you noticed that you are not fixing on this iteration.
-Documentation: Write extensive code comments in the code itself.
 Debugging: Code test coverage is measured by codecov. Write useful tests to increase it and check key requirements to hold.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,70 +1,70 @@
 # Important rules for agents
-Grasping what's up: Check out README.md.
-Make: Explain high-level architecture and quirks in Makefile
-AI: Use system prompts where needed.
-Pull requests: Branch names should match branch name recorded by Fibery if provided (e.g. "21648-switch-page-after-login-to-map").
-SQL: SQL is lowercase, PostGIS functions follow their spelling from the manual (`st_segmentize` -> `ST_Segmentize`).
-Style: Do not break code indentation.
-Debugging: Use TDD to handle bugs.
-SQL: Prefer indexed SQL operators when dealing with jsonb ( `tags @> '{"key": "value"}` instead of `tags ->> 'key' = 'value'` ).
-Style: Clean stuff up if you can: fix typos, make lexics more correct in English.
-Python: Write comments for each logical block.
-Make: To smoke-check Makefile, `make --trace all` helps see dependency chain.
-Testing: Github Actions is used as CI. Update it as necessary.
-AI: Check token counts.
-Pull requests: Keep Fibery ticket, Sentry ticket or other context relevant URL in pull request description.
-Front End: If Reatom v2 is used, upgrade it to v3.
-Debugging: Keep working until the tests pass, do not stop before that.
-SQL: Create both "up' and "down/rollback" migration when creating new migrations.
-Make: Remember that Makefile uses tabs.
+Debugging: Use docs/todo.md as to put issues, inconveniences and impediments that you noticed that you are not fixing on this iteration.
+SQL: Format queries in a way so it's easy to copy them out of the codebase and debug standalone.
+Testing: Always add a custom assertion message when writing assertions in unit tests, including as much context as possible. Incorporate input data and relevant test details so it's immediately clear what is being verified and why it might fail.
+k8s: When changing something in the charts, bump chart version to trigger deployment too.
+Testing: Code test coverage is measured by codecov. Write useful tests to increase it and check key requirements to hold.
+Debugging: Inject data assertions into IO abstraction libraries to catch any data that violates them.
+Pull requests: Use Conventional Commits convention when formatting the pull request and commits, e.g. `type(scope): TICKETNUMBER title ...`. Skip ticket number if not provided. Field: Public Id.
+Debugging: Make sure that error messages towards developer are better than just "500 Internal server error".
+SQL: Do not rewrite old migrations, not for style changes, not for logic changes, always create new migrations for any changes in DB
+Make: Makefile: If you need intermediate result from other target, split it into two and depend on the intermediate result.
 AI: Colloquial "vectors" are to be called "embeddings" in codebase.
-Style: Do not replace URLs with non-existing ones.
+Style: If a file with code grows longer than 500 lines, refactor it into two or move some parts into already created libraries.
+Documentation: docs/ folder has general project documentation that needs to be kept up to date.
+Testing: To run the pipeline in testing offline mode, launch `TEST_MODE=1 PYTHONPATH=. make -B -j all` and check if everything works as intended.
+Documentation: Every feature needs to have comprehensive up-to-date documentation near it.
+Debugging: Don't stub stuff out with insane fallbacks (like lat/lon=0) - instead make the rest of the code work around data absence and inform user.
+Style: Every feature needs to have comprehensive up-to-date documentation near it, write it.
+Debugging: Keep working until the tests pass, do not stop before that.
+Make: Format target comments as self-documented Makefile, on same line: `target: dependencies | order_only_deps ## Description`
+Debugging: Code test coverage is measured by codecov. Write useful tests to increase it and check key requirements to hold.
+Style: Clean stuff up if you can: fix typos, make lexics more correct in English.
+Debugging: When refactoring to move a feature, don't forget to remove the original code path.
 SQL: Values in databases and layers should be absolute as much as possible: store "birthday" or "construction date" instead of "age".
 Java: Write enough comments so that people proficient in Python, PostGIS can grasp the Java code.
-Documentation: Update docs every time you update something significant across files.
+Style: Do not replace URLs with non-existing ones.
+CI: The project is using Github Actions. Make sure its configuration is kept up-to-date.
 Style: Start sentences at new lines in docs for cleaner git diffs.
+AI: Try to make a patch to fix/improve things even if user's request sounds like a question.
+Style: Do not mix tabs and spaces in code.
+SQL: SQL is lowercase, PostGIS functions follow their spelling from the manual (`st_segmentize` -> `ST_Segmentize`).
+Pull requests: Branch names should match branch name recorded by Fibery if provided (e.g. "21648-switch-page-after-login-to-map").
+Python: Write docstrings, they will get used for call graph and generated documentation.
+SQL: SQL files should to be idempotent: drop table if exists; add some comments to make people grasp quereies faster.
+Testing: Github Actions is used as CI. Update it as necessary.
+Documentation: Fix everything in the `docs/` folder to match reality.
+AI: Use system prompts where needed.
+Style: Do not break code indentation.
+Debugging: When adding logs, add message before starting something as long as after finishing, as it will let you find what crashed in the middle.
+Make: To smoke-check Makefile, `make --trace all` helps see dependency chain.
 Java: Just ignoring exceptions is not the best fix, handle them properly.
 Make: Trivial oneliner SQLs are okay to keep in Makefile.
-Debugging: Inject data assertions into IO abstraction libraries to catch any data that violates them.
+Documentation: Don't update `README.md` with minor code fixes.
+Debugging: Use TDD to handle bugs.
+Documentation: Write extensive code comments in the code itself.
+Grasping what's up: Check out README.md.
+Style: Write insightful code comments.
+Grasping what's up: Check docs/
+Style: Add empty lines between logical blocks as in the rest of the codebase.
+Documentation: Update docs every time you update something significant across files.
+AI: Check token counts.
+Documentation: Prefer storing notes and documentation as markdown (`.md`).
+Front End: If Reatom v2 is used, upgrade it to v3.
+Debugging: File names may have spaces in them, check that you are correctly quoting and escaping them.
+SQL: Prefer indexed SQL operators when dealing with jsonb ( `tags @> '{"key": "value"}` instead of `tags ->> 'key' = 'value'` ).
+Python: Write comments for each logical block.
+Grasping what's up: Check data schema as described in `docs/`.
 Style: Format the code nicely and consistently.
 Debugging: Add enough debug logs so you can find out what's wrong but not be overwhelmed when something does not work as expected.
-Documentation: Every feature needs to have comprehensive up-to-date documentation near it.
-Grasping what's up: Check data schema as described in `docs/`.
-Debugging: Make sure that error messages towards developer are better than just "500 Internal server error".
-Documentation: Don't update `README.md` with minor code fixes.
-SQL: SQL files should to be idempotent: drop table if exists; add some comments to make people grasp quereies faster.
-k8s: When changing something in the charts, bump chart version to trigger deployment too.
-Pull requests: Use Conventional Commits convention when formatting the pull request and commits, e.g. `type(scope): TICKETNUMBER title ...`. Skip ticket number if not provided. Field: Public Id.
-Style: Write insightful code comments.
-AI: Try to make a patch to fix/improve things even if user's request sounds like a question.
-Make: Format target comments as self-documented Makefile, on same line: `target: dependencies | order_only_deps ## Description`
-Testing: To run the pipeline in testing offline mode, launch `TEST_MODE=1 PYTHONPATH=. make -B -j all` and check if everything works as intended.
-Style: If a file with code grows longer than 500 lines, refactor it into two or move some parts into already created libraries.
-Grasping what's up: Check docs/
-SQL: Format queries in a way so it's easy to copy them out of the codebase and debug standalone.
-Documentation: Prefer storing notes and documentation as markdown (`.md`).
-Testing: Always add a custom assertion message when writing assertions in unit tests, including as much context as possible. Incorporate input data and relevant test details so it's immediately clear what is being verified and why it might fail.
-Style: Add empty lines between logical blocks as in the rest of the codebase.
-Make: Makefile: If you need intermediate result from other target, split it into two and depend on the intermediate result.
-CI: The project is using Github Actions. Make sure its configuration is kept up-to-date.
-Style: Do not mix tabs and spaces in code.
-Debugging: Don't stub stuff out with insane fallbacks (like lat/lon=0) - instead make the rest of the code work around data absence and inform user.
-Documentation: docs/ folder has general project documentation that needs to be kept up to date.
-Debugging: When refactoring to move a feature, don't forget to remove the original code path.
-SQL: Do not rewrite old migrations, not for style changes, not for logic changes, always create new migrations for any changes in DB
-Debugging: When adding logs, add message before starting something as long as after finishing, as it will let you find what crashed in the middle.
-Python: Write docstrings, they will get used for call graph and generated documentation.
-Testing: Code test coverage is measured by codecov. Write useful tests to increase it and check key requirements to hold.
+Pull requests: Keep Fibery ticket, Sentry ticket or other context relevant URL in pull request description.
+SQL: Create both "up' and "down/rollback" migration when creating new migrations.
+Make: Remember that Makefile uses tabs.
 Documentation: API documentation is using Swagger, its descriptions should be clear for data consumers who don't have access to codebase.
-Debugging: File names may have spaces in them, check that you are correctly quoting and escaping them.
-Testing: Use `make precommit` to run the checks. This sorts files, verifies Makefile tabs and compiles all Python code via `scripts/check_python.sh`.
-Documentation: Fix everything in the `docs/` folder to match reality.
-Testing: For any fix you are implementing try to add test so that it won't repeat in the future.
-Style: Every feature needs to have comprehensive up-to-date documentation near it, write it.
-Debugging: Write enough comments so you can deduce what was a requirement in the future and not walk in circles.
-Documentation: When moving around md files also fix the links in them and links to them across all others.
+Make: Explain high-level architecture and quirks in Makefile
 Debugging: Use TDD if change is not trivial: start by designing solution/docs, then write tests, then change code to do the thing it should.
-Documentation: Write extensive code comments in the code itself.
+Documentation: When moving around md files also fix the links in them and links to them across all others.
+Testing: Use `make precommit` to run the checks. This sorts files, verifies Makefile tabs and compiles all Python code via `scripts/check_python.sh`.
+Testing: For any fix you are implementing try to add test so that it won't repeat in the future.
 Make: Makefile: there are comments on the same line after each target separated by ## - they are used in debug graph visualization, need to be concise and descriptive of what's going on in the code itself.
-Debugging: Use docs/todo.md as to put issues, inconveniences and impediments that you noticed that you are not fixing on this iteration.
-Debugging: Code test coverage is measured by codecov. Write useful tests to increase it and check key requirements to hold.
+Debugging: Write enough comments so you can deduce what was a requirement in the future and not walk in circles.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,98 +1,70 @@
 # Important rules for agents
-
-Grasping what's up:
- - Check out README.md.
- - Check docs/
- - Check data schema as described in `docs/`.
-
-Documentation:
- - docs/ folder has general project documentation that needs to be kept up to date.
- - Fix everything in the `docs/` folder to match reality.
- - Don't update `README.md` with minor code fixes.
- - When moving around md files also fix the links in them and links to them across all others.
- - Prefer storing notes and documentation as markdown (`.md`).
- - Update docs every time you update something significant across files.
- - Write extensive code comments in the code itself.
- - API documentation is using Swagger, its descriptions should be clear for data consumers who don't have access to codebase.
- - Every feature needs to have comprehensive up-to-date documentation near it.
-
-Debugging:
- - Write enough comments so you can deduce what was a requirement in the future and not walk in circles.
- - Add enough debug logs so you can find out what's wrong but not be overwhelmed when something does not work as expected.
- - Use TDD if change is not trivial: start by designing solution/docs, then write tests, then change code to do the thing it should.
- - Use TDD to handle bugs.
- - Code test coverage is measured by codecov. Write useful tests to increase it and check key requirements to hold.
- - When refactoring to move a feature, don't forget to remove the original code path.
- - Don't stub stuff out with insane fallbacks (like lat/lon=0) - instead make the rest of the code work around data absence and inform user.
- - File names may have spaces in them, check that you are correctly quoting and escaping them.
- - When adding logs, add message before starting something as long as after finishing, as it will let you find what crashed in the middle.
- - Inject data assertions into IO abstraction libraries to catch any data that violates them.
- - Use docs/todo.md as to put issues, inconveniences and impediments that you noticed that you are not fixing on this iteration.
- - Keep working until the tests pass, do not stop before that.
- - Make sure that error messages towards developer are better than just "500 Internal server error".
-
-Style:
- - Add empty lines between logical blocks as in the rest of the codebase.
- - Start sentences at new lines in docs for cleaner git diffs.
- - Clean stuff up if you can: fix typos, make lexics more correct in English.
- - Write insightful code comments.
- - Do not break code indentation.
- - Do not mix tabs and spaces in code.
- - Format the code nicely and consistently.
- - Do not replace URLs with non-existing ones.
- - If a file with code grows longer than 500 lines, refactor it into two or move some parts into already created libraries.
- - Every feature needs to have comprehensive up-to-date documentation near it, write it.
-
-Java:
- - Write enough comments so that people proficient in Python, PostGIS can grasp the Java code.
- - Just ignoring exceptions is not the best fix, handle them properly.
-
-SQL:
- - Prefer indexed SQL operators when dealing with jsonb ( `tags @> '{"key": "value"}` instead of `tags ->> 'key' = 'value'` ).
- - SQL is lowercase, PostGIS functions follow their spelling from the manual (`st_segmentize` -> `ST_Segmentize`).
- - Values in databases and layers should be absolute as much as possible: store "birthday" or "construction date" instead of "age".
- - SQL files should to be idempotent: drop table if exists; add some comments to make people grasp quereies faster.
- - Create both "up' and "down/rollback" migration when creating new migrations.
- - Format queries in a way so it's easy to copy them out of the codebase and debug standalone.
- - Do not rewrite old migrations, not for style changes, not for logic changes, always create new migrations for any changes in DB
-
-Make:
- - Makefile: If you need intermediate result from other target, split it into two and depend on the intermediate result.
- - Makefile: there are comments on the same line after each target separated by ## - they are used in debug graph visualization, need to be concise and descriptive of what's going on in the code itself.
- - Trivial oneliner SQLs are okay to keep in Makefile.
- - Format target comments as self-documented Makefile, on same line: `target: dependencies | order_only_deps ## Description`
- - Remember that Makefile uses tabs.
- - Explain high-level architecture and quirks in Makefile
- - To smoke-check Makefile, `make --trace all` helps see dependency chain.
-
-Python:
- - Write comments for each logical block.
- - Write docstrings, they will get used for call graph and generated documentation.
-
-Front End:
- - If Reatom v2 is used, upgrade it to v3.
-
-k8s:
- - When changing something in the charts, bump chart version to trigger deployment too.
-
-AI:
- - Try to make a patch to fix/improve things even if user's request sounds like a question.
- - Check token counts.
- - Use system prompts where needed.
- - Colloquial "vectors" are to be called "embeddings" in codebase.
-
-CI:
- - The project is using Github Actions. Make sure its configuration is kept up-to-date.
- 
-Testing:
- - Github Actions is used as CI. Update it as necessary.
- - Use `make precommit` to run the checks. This sorts files, verifies Makefile tabs and compiles all Python code via `scripts/check_python.sh`.
- - To run the pipeline in testing offline mode, launch `TEST_MODE=1 PYTHONPATH=. make -B -j all` and check if everything works as intended.
- - For any fix you are implementing try to add test so that it won't repeat in the future.
- - Code test coverage is measured by codecov. Write useful tests to increase it and check key requirements to hold.
- - Always add a custom assertion message when writing assertions in unit tests, including as much context as possible. Incorporate input data and relevant test details so it's immediately clear what is being verified and why it might fail.
-
-Pull requests:
- - Use Conventional Commits convention when formatting the pull request and commits, e.g. `type(scope): TICKETNUMBER title ...`. Skip ticket number if not provided. Field: Public Id.
- - Branch names should match branch name recorded by Fibery if provided (e.g. "21648-switch-page-after-login-to-map").
- - Keep Fibery ticket, Sentry ticket or other context relevant URL in pull request description.
+Grasping what's up: Check out README.md.
+Make: Explain high-level architecture and quirks in Makefile
+Pull requests: Branch names should match branch name recorded by Fibery if provided (e.g. "21648-switch-page-after-login-to-map").
+Debugging: Use TDD to handle bugs.
+Style: Do not break code indentation.
+SQL: Prefer indexed SQL operators when dealing with jsonb ( `tags @> '{"key": "value"}` instead of `tags ->> 'key' = 'value'` ).
+Front End: If Reatom v2 is used, upgrade it to v3.
+SQL: SQL is lowercase, PostGIS functions follow their spelling from the manual (`st_segmentize` -> `ST_Segmentize`).
+AI: Use system prompts where needed.
+Make: To smoke-check Makefile, `make --trace all` helps see dependency chain.
+Python: Write comments for each logical block.
+Style: Clean stuff up if you can: fix typos, make lexics more correct in English.
+Testing: Github Actions is used as CI. Update it as necessary.
+AI: Check token counts.
+Pull requests: Keep Fibery ticket, Sentry ticket or other context relevant URL in pull request description.
+Make: Remember that Makefile uses tabs.
+SQL: Create both "up' and "down/rollback" migration when creating new migrations.
+Debugging: Keep working until the tests pass, do not stop before that.
+Style: Format the code nicely and consistently.
+Documentation: docs/ folder has general project documentation that needs to be kept up to date.
+Style: Do not replace URLs with non-existing ones.
+AI: Colloquial "vectors" are to be called "embeddings" in codebase.
+Debugging: Add enough debug logs so you can find out what's wrong but not be overwhelmed when something does not work as expected.
+SQL: Values in databases and layers should be absolute as much as possible: store "birthday" or "construction date" instead of "age".
+Java: Write enough comments so that people proficient in Python, PostGIS can grasp the Java code.
+Make: Trivial oneliner SQLs are okay to keep in Makefile.
+AI: Try to make a patch to fix/improve things even if user's request sounds like a question.
+Documentation: Don't update `README.md` with minor code fixes.
+Style: Start sentences at new lines in docs for cleaner git diffs.
+Debugging: Make sure that error messages towards developer are better than just "500 Internal server error".
+Testing: To run the pipeline in testing offline mode, launch `TEST_MODE=1 PYTHONPATH=. make -B -j all` and check if everything works as intended.
+k8s: When changing something in the charts, bump chart version to trigger deployment too.
+Grasping what's up: Check data schema as described in `docs/`.
+Java: Just ignoring exceptions is not the best fix, handle them properly.
+Make: Format target comments as self-documented Makefile, on same line: `target: dependencies | order_only_deps ## Description`
+Pull requests: Use Conventional Commits convention when formatting the pull request and commits, e.g. `type(scope): TICKETNUMBER title ...`. Skip ticket number if not provided. Field: Public Id.
+Documentation: Every feature needs to have comprehensive up-to-date documentation near it.
+SQL: SQL files should to be idempotent: drop table if exists; add some comments to make people grasp quereies faster.
+Style: If a file with code grows longer than 500 lines, refactor it into two or move some parts into already created libraries.
+SQL: Format queries in a way so it's easy to copy them out of the codebase and debug standalone.
+Style: Write insightful code comments.
+Grasping what's up: Check docs/
+Testing: Always add a custom assertion message when writing assertions in unit tests, including as much context as possible. Incorporate input data and relevant test details so it's immediately clear what is being verified and why it might fail.
+Documentation: Prefer storing notes and documentation as markdown (`.md`).
+CI: The project is using Github Actions. Make sure its configuration is kept up-to-date.
+Debugging: Don't stub stuff out with insane fallbacks (like lat/lon=0) - instead make the rest of the code work around data absence and inform user.
+Make: Makefile: If you need intermediate result from other target, split it into two and depend on the intermediate result.
+SQL: Do not rewrite old migrations, not for style changes, not for logic changes, always create new migrations for any changes in DB
+Debugging: When refactoring to move a feature, don't forget to remove the original code path.
+Documentation: Update docs every time you update something significant across files.
+Style: Do not mix tabs and spaces in code.
+Debugging: Inject data assertions into IO abstraction libraries to catch any data that violates them.
+Style: Add empty lines between logical blocks as in the rest of the codebase.
+Python: Write docstrings, they will get used for call graph and generated documentation.
+Debugging: When adding logs, add message before starting something as long as after finishing, as it will let you find what crashed in the middle.
+Testing: Code test coverage is measured by codecov. Write useful tests to increase it and check key requirements to hold.
+Testing: Use `make precommit` to run the checks. This sorts files, verifies Makefile tabs and compiles all Python code via `scripts/check_python.sh`.
+Documentation: API documentation is using Swagger, its descriptions should be clear for data consumers who don't have access to codebase.
+Debugging: File names may have spaces in them, check that you are correctly quoting and escaping them.
+Documentation: Fix everything in the `docs/` folder to match reality.
+Testing: For any fix you are implementing try to add test so that it won't repeat in the future.
+Debugging: Use TDD if change is not trivial: start by designing solution/docs, then write tests, then change code to do the thing it should.
+Style: Every feature needs to have comprehensive up-to-date documentation near it, write it.
+Documentation: When moving around md files also fix the links in them and links to them across all others.
+Debugging: Write enough comments so you can deduce what was a requirement in the future and not walk in circles.
+Make: Makefile: there are comments on the same line after each target separated by ## - they are used in debug graph visualization, need to be concise and descriptive of what's going on in the code itself.
+Debugging: Use docs/todo.md as to put issues, inconveniences and impediments that you noticed that you are not fixing on this iteration.
+Documentation: Write extensive code comments in the code itself.
+Debugging: Code test coverage is measured by codecov. Write useful tests to increase it and check key requirements to hold.

--- a/AGENTS.raw.md
+++ b/AGENTS.raw.md
@@ -1,0 +1,98 @@
+# Important rules for agents
+
+Grasping what's up:
+ - Check out README.md.
+ - Check docs/
+ - Check data schema as described in `docs/`.
+
+Documentation:
+ - docs/ folder has general project documentation that needs to be kept up to date.
+ - Fix everything in the `docs/` folder to match reality.
+ - Don't update `README.md` with minor code fixes.
+ - When moving around md files also fix the links in them and links to them across all others.
+ - Prefer storing notes and documentation as markdown (`.md`).
+ - Update docs every time you update something significant across files.
+ - Write extensive code comments in the code itself.
+ - API documentation is using Swagger, its descriptions should be clear for data consumers who don't have access to codebase.
+ - Every feature needs to have comprehensive up-to-date documentation near it.
+
+Debugging:
+ - Write enough comments so you can deduce what was a requirement in the future and not walk in circles.
+ - Add enough debug logs so you can find out what's wrong but not be overwhelmed when something does not work as expected.
+ - Use TDD if change is not trivial: start by designing solution/docs, then write tests, then change code to do the thing it should.
+ - Use TDD to handle bugs.
+ - Code test coverage is measured by codecov. Write useful tests to increase it and check key requirements to hold.
+ - When refactoring to move a feature, don't forget to remove the original code path.
+ - Don't stub stuff out with insane fallbacks (like lat/lon=0) - instead make the rest of the code work around data absence and inform user.
+ - File names may have spaces in them, check that you are correctly quoting and escaping them.
+ - When adding logs, add message before starting something as long as after finishing, as it will let you find what crashed in the middle.
+ - Inject data assertions into IO abstraction libraries to catch any data that violates them.
+ - Use docs/todo.md as to put issues, inconveniences and impediments that you noticed that you are not fixing on this iteration.
+ - Keep working until the tests pass, do not stop before that.
+ - Make sure that error messages towards developer are better than just "500 Internal server error".
+
+Style:
+ - Add empty lines between logical blocks as in the rest of the codebase.
+ - Start sentences at new lines in docs for cleaner git diffs.
+ - Clean stuff up if you can: fix typos, make lexics more correct in English.
+ - Write insightful code comments.
+ - Do not break code indentation.
+ - Do not mix tabs and spaces in code.
+ - Format the code nicely and consistently.
+ - Do not replace URLs with non-existing ones.
+ - If a file with code grows longer than 500 lines, refactor it into two or move some parts into already created libraries.
+ - Every feature needs to have comprehensive up-to-date documentation near it, write it.
+
+Java:
+ - Write enough comments so that people proficient in Python, PostGIS can grasp the Java code.
+ - Just ignoring exceptions is not the best fix, handle them properly.
+
+SQL:
+ - Prefer indexed SQL operators when dealing with jsonb ( `tags @> '{"key": "value"}` instead of `tags ->> 'key' = 'value'` ).
+ - SQL is lowercase, PostGIS functions follow their spelling from the manual (`st_segmentize` -> `ST_Segmentize`).
+ - Values in databases and layers should be absolute as much as possible: store "birthday" or "construction date" instead of "age".
+ - SQL files should to be idempotent: drop table if exists; add some comments to make people grasp quereies faster.
+ - Create both "up' and "down/rollback" migration when creating new migrations.
+ - Format queries in a way so it's easy to copy them out of the codebase and debug standalone.
+ - Do not rewrite old migrations, not for style changes, not for logic changes, always create new migrations for any changes in DB
+
+Make:
+ - Makefile: If you need intermediate result from other target, split it into two and depend on the intermediate result.
+ - Makefile: there are comments on the same line after each target separated by ## - they are used in debug graph visualization, need to be concise and descriptive of what's going on in the code itself.
+ - Trivial oneliner SQLs are okay to keep in Makefile.
+ - Format target comments as self-documented Makefile, on same line: `target: dependencies | order_only_deps ## Description`
+ - Remember that Makefile uses tabs.
+ - Explain high-level architecture and quirks in Makefile
+ - To smoke-check Makefile, `make --trace all` helps see dependency chain.
+
+Python:
+ - Write comments for each logical block.
+ - Write docstrings, they will get used for call graph and generated documentation.
+
+Front End:
+ - If Reatom v2 is used, upgrade it to v3.
+
+k8s:
+ - When changing something in the charts, bump chart version to trigger deployment too.
+
+AI:
+ - Try to make a patch to fix/improve things even if user's request sounds like a question.
+ - Check token counts.
+ - Use system prompts where needed.
+ - Colloquial "vectors" are to be called "embeddings" in codebase.
+
+CI:
+ - The project is using Github Actions. Make sure its configuration is kept up-to-date.
+ 
+Testing:
+ - Github Actions is used as CI. Update it as necessary.
+ - Use `make precommit` to run the checks. This sorts files, verifies Makefile tabs and compiles all Python code via `scripts/check_python.sh`.
+ - To run the pipeline in testing offline mode, launch `TEST_MODE=1 PYTHONPATH=. make -B -j all` and check if everything works as intended.
+ - For any fix you are implementing try to add test so that it won't repeat in the future.
+ - Code test coverage is measured by codecov. Write useful tests to increase it and check key requirements to hold.
+ - Always add a custom assertion message when writing assertions in unit tests, including as much context as possible. Incorporate input data and relevant test details so it's immediately clear what is being verified and why it might fail.
+
+Pull requests:
+ - Use Conventional Commits convention when formatting the pull request and commits, e.g. `type(scope): TICKETNUMBER title ...`. Skip ticket number if not provided. Field: Public Id.
+ - Branch names should match branch name recorded by Fibery if provided (e.g. "21648-switch-page-after-login-to-map").
+ - Keep Fibery ticket, Sentry ticket or other context relevant URL in pull request description.

--- a/scripts/spaced_repetition.py
+++ b/scripts/spaced_repetition.py
@@ -6,17 +6,16 @@ RAW_FILE = Path('AGENTS.raw.md')
 original_text = SOURCE_FILE.read_text()
 RAW_FILE.write_text(original_text)
 
-# parse headers and items from RAW_FILE
 lines = original_text.splitlines()
 if not lines:
     raise ValueError('AGENTS.md expected to contain data but is empty')
+
 first_line = lines[0]
 
-items = []
+items: list[str] = []
 current_header = None
-for line in lines:
+for line in lines[1:]:
     if line.startswith('#'):
-        # treat header as is
         current_header = line.lstrip('# ').rstrip(':')
     elif line.startswith(' - '):
         text = line[3:].strip()
@@ -25,37 +24,72 @@ for line in lines:
         else:
             items.append(text)
     elif line.strip():
-        # treat as plain line
         current_header = line.strip().rstrip(':')
 
 if not items:
-    items = [line.strip() for line in lines if line.strip()]
+    items = [line.strip() for line in lines[1:] if line.strip()]
 
-# trigram similarity
+# trigram similarity utilities
+
 def trigrams(s: str) -> set[str]:
     s = s.lower()
     return {s[i:i+3] for i in range(len(s) - 2)} if len(s) >= 3 else {s}
 
-def trigram_similarity(a, b):
+
+def trigram_similarity(a: str, b: str) -> float:
     ta, tb = trigrams(a), trigrams(b)
     union = ta | tb
-    if not union:
-        return 0.0
-    return len(ta & tb) / len(union)
+    return len(ta & tb) / len(union) if union else 0.0
 
-ordered = [first_line]
-remaining = items
+
+def distance(a: str, b: str) -> float:
+    return 1 - trigram_similarity(a, b)
+
+
+n = len(items)
+if n == 0:
+    Path('AGENTS.md').write_text(original_text)
+    raise SystemExit
+
+# precompute distance matrix
+matrix = [[distance(ai, bj) for bj in items] for ai in items]
+
+# pick first item least similar to the header
+header_dists = [distance(first_line, it) for it in items]
+first_idx = max(range(n), key=lambda i: header_dists[i])
+path = [first_idx]
+remaining = set(range(n)) - {first_idx}
+
+# choose second item farthest from the first
 if remaining:
-    ordered.append(remaining[0])
-    remaining = remaining[1:]
-while remaining:
-    scores = []
-    for item in remaining:
-        score = sum(trigram_similarity(item, prev) for prev in ordered)
-        scores.append((score, item))
-    scores.sort()
-    ordered.append(scores[0][1])
-    remaining.remove(scores[0][1])
+    second_idx = max(remaining, key=lambda i: matrix[first_idx][i])
+    path.append(second_idx)
+    remaining.remove(second_idx)
 
-# write result
-Path('AGENTS.md').write_text('\n'.join(ordered) + '\n')
+while remaining:
+    best_item = None
+    best_end = None  # 'start' or 'end'
+    best_dist = -1.0
+    start_item = path[0]
+    end_item = path[-1]
+    for r in remaining:
+        d_start = matrix[r][start_item]
+        d_end = matrix[end_item][r]
+        if d_start > best_dist or d_end > best_dist:
+            if d_start >= d_end:
+                best_dist = d_start
+                best_item = r
+                best_end = 'start'
+            else:
+                best_dist = d_end
+                best_item = r
+                best_end = 'end'
+    if best_end == 'start':
+        path.insert(0, best_item)
+    else:
+        path.append(best_item)
+    remaining.remove(best_item)
+
+ordered_items = [items[i] for i in path]
+ordered_text = '\n'.join([first_line] + ordered_items) + '\n'
+Path('AGENTS.md').write_text(ordered_text)

--- a/scripts/spaced_repetition.py
+++ b/scripts/spaced_repetition.py
@@ -1,5 +1,3 @@
-import os
-import re
 from pathlib import Path
 
 SOURCE_FILE = Path('AGENTS.md')
@@ -11,7 +9,7 @@ RAW_FILE.write_text(original_text)
 # parse headers and items from RAW_FILE
 lines = original_text.splitlines()
 if not lines:
-    raise SystemExit('AGENTS.md is empty')
+    raise ValueError('AGENTS.md expected to contain data but is empty')
 first_line = lines[0]
 
 items = []
@@ -34,7 +32,8 @@ if not items:
     items = [line.strip() for line in lines if line.strip()]
 
 # trigram similarity
-def trigrams(s):
+def trigrams(s: str) -> set[str]:
+    s = s.lower()
     return {s[i:i+3] for i in range(len(s) - 2)} if len(s) >= 3 else {s}
 
 def trigram_similarity(a, b):

--- a/scripts/spaced_repetition.py
+++ b/scripts/spaced_repetition.py
@@ -1,0 +1,62 @@
+import os
+import re
+from pathlib import Path
+
+SOURCE_FILE = Path('AGENTS.md')
+RAW_FILE = Path('AGENTS.raw.md')
+
+original_text = SOURCE_FILE.read_text()
+RAW_FILE.write_text(original_text)
+
+# parse headers and items from RAW_FILE
+lines = original_text.splitlines()
+if not lines:
+    raise SystemExit('AGENTS.md is empty')
+first_line = lines[0]
+
+items = []
+current_header = None
+for line in lines:
+    if line.startswith('#'):
+        # treat header as is
+        current_header = line.lstrip('# ').rstrip(':')
+    elif line.startswith(' - '):
+        text = line[3:].strip()
+        if current_header:
+            items.append(f"{current_header}: {text}")
+        else:
+            items.append(text)
+    elif line.strip():
+        # treat as plain line
+        current_header = line.strip().rstrip(':')
+
+if not items:
+    items = [line.strip() for line in lines if line.strip()]
+
+# trigram similarity
+def trigrams(s):
+    return {s[i:i+3] for i in range(len(s) - 2)} if len(s) >= 3 else {s}
+
+def trigram_similarity(a, b):
+    ta, tb = trigrams(a), trigrams(b)
+    union = ta | tb
+    if not union:
+        return 0.0
+    return len(ta & tb) / len(union)
+
+ordered = [first_line]
+remaining = items
+if remaining:
+    ordered.append(remaining[0])
+    remaining = remaining[1:]
+while remaining:
+    scores = []
+    for item in remaining:
+        score = sum(trigram_similarity(item, prev) for prev in ordered)
+        scores.append((score, item))
+    scores.sort()
+    ordered.append(scores[0][1])
+    remaining.remove(scores[0][1])
+
+# write result
+Path('AGENTS.md').write_text('\n'.join(ordered) + '\n')


### PR DESCRIPTION
## Summary
- add spaced repetition generator script
- store original AGENTS content to AGENTS.raw.md
- generate spaced AGENTS.md ordering items by trigram dissimilarity
- run generator in GitHub Actions on pushes to main

## Testing
- `make precommit` *(fails: No rule to make target)*


------
https://chatgpt.com/codex/tasks/task_b_688a543a5a248326bc4dbd0d3d05f21f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an automated workflow to process and update agent guidelines documentation.
  * Added a comprehensive raw guidelines document for agents.
  * Implemented a script that reorganizes agent guidelines to maximize informational diversity.

* **Documentation**
  * Simplified the main agent guidelines document to a concise, high-level checklist.
  * Added a detailed raw guidelines file outlining best practices and standards for project contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->